### PR TITLE
Async requests to moby for speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ docker run -d --restart=unless-stopped -v /var/run/docker.sock:/var/run/docker.s
 ## Docker compose
 
 ```
-github-exporter:
+moby-container-exporter:
     tty: true
     stdin_open: true
     ports:

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # Moby Container Stats
 
-Exposes basic metrics for your containers directly from the moby stats API to a prometheus compatible endpoint. Doing a similar job to the popular cAdvisor application, this is a much more lightweight and simplified design for just the key metrics that people require. It requires less resources to run as an exporter on your hosts, it's also less expensive to store in prometheus.
+Exposes basic metrics for your containers directly from the moby stats API to a prometheus compatible endpoint. Doing a similar job to the popular cAdvisor application, this is a much more lightweight and simplified design for just the key metrics that people require. It requires less resources to run as an exporter on your hosts, it's also less expensive to store in prometheus. Metrics are obtained through async calls to the moby stats API over the Docker socket. Scrapes can sometimes take up to 2 seconds, this is due to the inherent way moby calculates it's CPU usage at present. Ideally, the work Docker are doing towards native prometheus metrics for containers will render this exporter obsolete.
 
 ## Configuration
 
-This exporter is setup to take input from environment variables:
+This exporter is setup to take input from environment variables, please make sure you also map in the docker socket to the container, details below.
 
 ### Required
 None..
@@ -21,13 +21,13 @@ None..
 
 Run manually from Docker Hub:
 ```
-docker run -d --restart=always -p 9244:9244 infinityworks/moby-container-stats
+docker run -d --restart=unless-stopped -v /var/run/docker.sock:/var/run/docker.sock -p 9244:9244 infinityworks/moby-container-stats
 ```
 
 Build a docker image:
 ```
 docker build -t <image-name> .
-docker run -d --restart=always -p 9244:9244 <image-name>
+docker run -d --restart=unless-stopped -v /var/run/docker.sock:/var/run/docker.sock -p 9244:9244 <image-name>
 ```
 
 ## Docker compose
@@ -38,6 +38,8 @@ github-exporter:
     stdin_open: true
     ports:
       - 9244:9244
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     image: infinityworks/moby-container-stats:latest
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![](https://images.microbadger.com/badges/image/infinityworks/moby-container-stats.svg)](http://microbadger.com/images/infinityworks/moby-container-stats "Get your own image badge on microbadger.com") [![](https://images.microbadger.com/badges/version/infinityworks/moby-container-stats.svg)](http://microbadger.com/images/infinityworks/moby-container-stats "Get your own version badge on microbadger.com")
+[![Go Report Card](https://goreportcard.com/badge/github.com/infinityworks/moby-container-stats)](https://goreportcard.com/report/github.com/infinityworks/moby-container-stats)[![](https://images.microbadger.com/badges/image/infinityworks/moby-container-stats.svg)](http://microbadger.com/images/infinityworks/moby-container-stats "Get your own image badge on microbadger.com") [![](https://images.microbadger.com/badges/version/infinityworks/moby-container-stats.svg)](http://microbadger.com/images/infinityworks/moby-container-stats "Get your own version badge on microbadger.com")
 
 # Moby Container Stats
 

--- a/calc.go
+++ b/calc.go
@@ -1,6 +1,6 @@
 package main
 
-func calcCPUPercent(stats *ContainerStats) float64 {
+func calcCPUPercent(stats *ContainerMetrics) float64 {
 
 	var CPUPercent float64
 
@@ -14,6 +14,6 @@ func calcCPUPercent(stats *ContainerStats) float64 {
 	return CPUPercent
 }
 
-func calcMemoryPercent(stats *ContainerStats) float64 {
+func calcMemoryPercent(stats *ContainerMetrics) float64 {
 	return float64(stats.MemoryStats.Usage) * 100.0 / float64(stats.MemoryStats.Limit)
 }

--- a/prometheus.go
+++ b/prometheus.go
@@ -19,11 +19,41 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	eLogger.Debug("Metric collection requested")
 
-	err := e.getStats(ch)
+	metrics, err := e.asyncRetrieveMetrics()
 	if err != nil {
 		fmt.Println("Error encountered", err)
 	}
 
+	for _, b := range metrics {
+		e.setPrometheusMetrics(b, ch)
+	}
+
 	eLogger.Debug("Metrics successfully collected")
+
+}
+
+// setPrometheusMetrics takes the pointer to ContainerMetrics and uses the data to set the guages and counters
+func (e *Exporter) setPrometheusMetrics(stats *ContainerMetrics, ch chan<- prometheus.Metric) {
+
+	// Set CPU metrics
+	ch <- prometheus.MustNewConstMetric(e.containerMetrics["cpuUsagePercent"], prometheus.GaugeValue, calcCPUPercent(stats), stats.Name, stats.ID)
+
+	// Set Memory metrics
+	ch <- prometheus.MustNewConstMetric(e.containerMetrics["memoryUsagePercent"], prometheus.GaugeValue, calcMemoryPercent(stats), stats.Name, stats.ID)
+	ch <- prometheus.MustNewConstMetric(e.containerMetrics["memoryUsageBytes"], prometheus.GaugeValue, float64(stats.MemoryStats.Usage), stats.Name, stats.ID)
+	ch <- prometheus.MustNewConstMetric(e.containerMetrics["memoryLimit"], prometheus.GaugeValue, float64(stats.MemoryStats.Limit), stats.Name, stats.ID)
+
+	// Network interface stats (loop through the map of returned interfaces)
+	for key, net := range stats.NetIntefaces {
+
+		ch <- prometheus.MustNewConstMetric(e.containerMetrics["rxBytes"], prometheus.GaugeValue, float64(net.RxBytes), stats.Name, stats.ID, key)
+		ch <- prometheus.MustNewConstMetric(e.containerMetrics["rxDropped"], prometheus.GaugeValue, float64(net.RxDropped), stats.Name, stats.ID, key)
+		ch <- prometheus.MustNewConstMetric(e.containerMetrics["rxErrors"], prometheus.GaugeValue, float64(net.RxErrors), stats.Name, stats.ID, key)
+		ch <- prometheus.MustNewConstMetric(e.containerMetrics["rxPackets"], prometheus.GaugeValue, float64(net.RxPackets), stats.Name, stats.ID, key)
+		ch <- prometheus.MustNewConstMetric(e.containerMetrics["txBytes"], prometheus.GaugeValue, float64(net.TxBytes), stats.Name, stats.ID, key)
+		ch <- prometheus.MustNewConstMetric(e.containerMetrics["txDropped"], prometheus.GaugeValue, float64(net.TxDropped), stats.Name, stats.ID, key)
+		ch <- prometheus.MustNewConstMetric(e.containerMetrics["txErrors"], prometheus.GaugeValue, float64(net.TxErrors), stats.Name, stats.ID, key)
+		ch <- prometheus.MustNewConstMetric(e.containerMetrics["txPackets"], prometheus.GaugeValue, float64(net.TxPackets), stats.Name, stats.ID, key)
+	}
 
 }


### PR DESCRIPTION
- Now uses async requests through go channels to retrieve the container stats. Much quicker now to do over the existing codebase.
-  Small documentation tweaks