### PR TITLE
Export memory cache stats

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -25,6 +25,11 @@ func Return() map[string]*prometheus.Desc {
 		"Current memory usage in bytes for the specified container",
 		[]string{"container_id", "container_name"}, nil,
 	)
+	containerMetrics["memoryCacheBytes"] = prometheus.NewDesc(
+		prometheus.BuildFQName("container", "memory", "cache_bytes"),
+		"Current memory cache in bytes for the specified container",
+		[]string{"container_id", "container_name"}, nil,
+	)
 	containerMetrics["memoryLimit"] = prometheus.NewDesc(
 		prometheus.BuildFQName("container", "memory", "limit"),
 		"Memory limit as configured for the specified container",

--- a/moby.go
+++ b/moby.go
@@ -26,6 +26,9 @@ type ContainerMetrics struct {
 	MemoryStats struct {
 		Usage int `json:"usage"`
 		Limit int `json:"limit"`
+		Stats struct {
+			Cache int `json:"cache"`
+		} `json:"stats"`
 	} `json:"memory_stats"`
 	CPUStats struct {
 		CPUUsage struct {

--- a/prometheus.go
+++ b/prometheus.go
@@ -43,6 +43,7 @@ func (e *Exporter) setPrometheusMetrics(stats *ContainerMetrics, ch chan<- prome
 	// Set Memory metrics
 	ch <- prometheus.MustNewConstMetric(e.containerMetrics["memoryUsagePercent"], prometheus.GaugeValue, calcMemoryPercent(stats), stats.ID, stats.Name)
 	ch <- prometheus.MustNewConstMetric(e.containerMetrics["memoryUsageBytes"], prometheus.GaugeValue, float64(stats.MemoryStats.Usage), stats.ID, stats.Name)
+	ch <- prometheus.MustNewConstMetric(e.containerMetrics["memoryCacheBytes"], prometheus.GaugeValue, float64(stats.MemoryStats.Stats.Cache), stats.ID, stats.Name)
 	ch <- prometheus.MustNewConstMetric(e.containerMetrics["memoryLimit"], prometheus.GaugeValue, float64(stats.MemoryStats.Limit), stats.ID, stats.Name)
 
 	if len(stats.NetIntefaces) == 0 {


### PR DESCRIPTION
The docker stats CLI displays the memory usage without cache (https://github.com/docker/cli/pull/80).

This PR exports the memory cache value alongside the usage bytes, so prometheus clients can calculate a CLI compatible metric. Existing moby-container-stats users should not be affected by this change.